### PR TITLE
changed mbed cli hyperlink to install guide page

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Features/fixes can only be added with a pull request. Branches should be named a
 - Feature: `feature/<short description>`
 
 ### Required tools
-- [mbed cli](https://github.com/ARMmbed/mbed-cli)
+- [mbed cli](https://os.mbed.com/docs/mbed-os/v6.2/quick-start/build-with-mbed-cli.html)
 - [GNU Arm Embedded Toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm)
     - Ubuntu/Debian: `gcc-arm-none-eabi`
     - Brew: `gcc-arm-embedded`


### PR DESCRIPTION
The current mbed cli hyperlink leads to a self referencing README which doesn't document the installation process. The updated link leads directly to the mbed install guide page. Hope this saves someone 30 seconds of googling in the future